### PR TITLE
Revert 128 copilot/fix 52e97304 a0b0 41b4 a536 e51f7ee4aca3

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -51,10 +51,6 @@ RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master
 # Install Roslynator CLI globally
 RUN dotnet tool install -g roslynator.dotnet.cli
 
-# Install Entity Framework Core CLI tools globally
-RUN dotnet tool install -g dotnet-ef --version 8.0.8
-ENV PATH="${PATH}:/root/.dotnet/tools"
-
 # Clean up
 RUN apt-get clean
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,7 +452,10 @@ jobs:
       - name: Verify EF design-time uses Sqlite (run on macOS build only)
         if: matrix.tfm == 'net8.0-ios'
         run: |
-          dotnet tool restore || true
+          if ! dotnet tool restore; then
+            echo "❌ dotnet tool restore failed. Please check your tool manifest and environment."
+            exit 1
+          fi
           dotnet ef dbcontext info -p ./PhysicallyFitPT.Infrastructure
 
       - name: Run unit tests (macOS only, since tests require Infrastructure)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,9 +452,8 @@ jobs:
       - name: Verify EF design-time uses Sqlite (run on macOS build only)
         if: matrix.tfm == 'net8.0-ios'
         run: |
-          # Ensure dotnet-ef tool is available
-          dotnet tool restore || dotnet tool install --global dotnet-ef --version 8.0.8
-          dotnet ef dbcontext info -p ./src/PhysicallyFitPT.Infrastructure
+          dotnet tool restore || true
+          dotnet ef dbcontext info -p ./PhysicallyFitPT.Infrastructure
 
       - name: Run unit tests (macOS only, since tests require Infrastructure)
         if: matrix.tfm == 'net8.0-ios'

--- a/src/PhysicallyFitPT.Web/packages.lock.json
+++ b/src/PhysicallyFitPT.Web/packages.lock.json
@@ -48,9 +48,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.20, )",
-        "resolved": "8.0.20",
-        "contentHash": "Rhcto2AjGvTO62+/VTmBpumBOmqIGp7nYEbTbmEXkCq4yPGxV8whju3/HsIA/bKyo2+DggaYk5+/8sxb1AbPTw=="
+        "requested": "[8.0.19, )",
+        "resolved": "8.0.19",
+        "contentHash": "IhHf+zeZiaE5EXRyxILd4qM+Hj9cxV3sa8MpzZgeEhpvaG3a1VEGF6UCaPFLO44Kua3JkLKluE0SWVamS50PlA=="
       },
       "Microsoft.NET.Sdk.WebAssembly.Pack": {
         "type": "Direct",


### PR DESCRIPTION
# PR Checklist

- [ ] Web is DB-stateless: no DbContext/EF packages and no Infrastructure reference.
- [ ] Devices include EF Core + SQLite and publish successfully.
- [ ] EF design-time check passes with `EF_PROVIDER=sqlite`.
- [ ] CI guardrails added/maintained.
- [ ] CHANGELOG updated by CI on this PR with job outcomes (✅ emphasized on success).

## Summary

Explain what changed and why, linking to docs where helpful. The Web must remain API-only with no database dependencies.

## Verification

- Commands run locally (build/publish, EF design-time):
  - `dotnet build ./PhysicallyFitPT.Web/PhysicallyFitPT.Web.csproj -c Release -f net8.0`
  - `dotnet publish ./PhysicallyFitPT/PhysicallyFitPT.csproj -c Release -f net8.0-android`
  - `dotnet publish ./PhysicallyFitPT/PhysicallyFitPT.csproj -c Release -f net8.0-ios`
  - `dotnet publish ./PhysicallyFitPT/PhysicallyFitPT.csproj -c Release -f net8.0-maccatalyst`
  - `EF_PROVIDER=sqlite dotnet ef dbcontext info -p ./PhysicallyFitPT.Infrastructure -s ./PhysicallyFitPT/PhysicallyFitPT.csproj`

## Changelog as Primary Context

Reviewers and agents: treat [`/docs/CHANGELOG.md`](../docs/CHANGELOG.md) as a primary context document for this repository. The workflow generates or updates it first to guide subsequent tasks with minimal premium API calls.